### PR TITLE
refer to nemo-vertices with path relative to cmor-fixer.py instead of…

### DIFF
--- a/cmor-fixer.py
+++ b/cmor-fixer.py
@@ -30,7 +30,9 @@ orca025_grid_shape = (1050, 1442, 4)
 
 def load_vertices(vertices_file_name):
     # Loading once at the start the NEMO longitude and latitude vertices from a netcdf file:
-    nemo_vertices_file_name=os.path.join("nemo-vertices", vertices_file_name)
+    scriptdir=os.path.dirname(__file__)
+    nemoverticespath=scriptdir+"/nemo-vertices"
+    nemo_vertices_file_name=os.path.join(nemoverticespath, vertices_file_name)
     if os.path.isfile(nemo_vertices_file_name) == False: print(error_message, ' The netcdf data file ', nemo_vertices_file_name, '  does not exist.\n'); sys.exit()
     nemo_vertices_netcdf_file = netCDF4.Dataset(nemo_vertices_file_name, 'r')
     lon_vertices_from_nemo_tmp = nemo_vertices_netcdf_file.variables["vertices_longitude"]
@@ -280,6 +282,8 @@ def main(args=None):
                              "file will be skipped unless the --addatts option is used.")
     parser.add_argument("--olist", "-o", action="store_true", default=False,
                         help="Write list-of-modified-files.txt listing all modified files")
+    parser.add_argument("--output-dir", default=None, type=str,
+                        help="alternate directory to write output file to (optional)")
     parser.add_argument("--addattrs", "-a", action="store_true", default=False,
                         help="Add new attributes from metadata file")
     parser.add_argument("--npp", type=int, default=1, help="Number of sub-processes to launch (default 1)")
@@ -295,6 +299,11 @@ def main(args=None):
         log.error("Options keepid and forceid are mutually exclusive, please choose either one.")
         return
     odir = args.datadir
+    outputdir=args.output_dir
+    if not outputdir == None:
+        if not os.path.isdir(outputdir):
+            log.error("Invalid output directory %s. Skipping run." % outputdir)
+            return
     depth = getattr(args, "depth", None)
     metajson = getattr(args, "meta", None)
     metadata = None
@@ -308,11 +317,15 @@ def main(args=None):
         log.error("Invalid number of subprocesses chosen, please pick a number > 0")
         return
     ofilename = "list-of-modified-files.txt"
+    if not outputdir == None:
+        ofilename="%s/%s"%(outputdir,ofilename)
     if args.olist and os.path.isfile(ofilename):
         i = 1
         while os.path.isfile(ofilename):
             i += 1
             newfilename = "list-of-modified-files-" + str(i) + ".txt"
+            if not outputdir == None:
+                newfilename="%s/list-of-modified-files-"%(outputdir)+str(i)+".txt"
             log.warning("Output file name %s already exists, trying %s..." % (ofilename, newfilename))
             ofilename = newfilename
     if args.npp == 1:


### PR DESCRIPTION
1. nemo-vertices location is assumed to be available in the current directory instead of a path relative-from the location of cmor-fixer.py script, which makes it impossible to execute the script from any other location.
This is vital if the script needs to be called from other directories or scripts, without first being forced to do a change-directory.

pwd
/home/pchengi
(cmorfixer) pchengi@thebeast:~$ /home/pchengi/cmor-fixer/cmor-fixer.py --verbose --npp 1 --dry /home/pchengi/cmorfixtest/newtest

 Error:  The netcdf data file  nemo-vertices/nemo-vertices-ORCA1-t-grid.nc   does not exist.

Solution: the location of nemo-vertices directory should be made relative to the position of cmor-fixer.py.

Output from fixed code:

/home/pchengi/cmor-fixer_modified/cmor-fixer/cmor-fixer.py --verbose --npp 1 --dry /home/pchengi/cmorfixtest/newtest
2024-11-01 13:59:09 INFO:cmor-fixer.py: Replacing the longitude and latitude t-grid vertices for vertices_longitude (none) in /home/pchengi/cmorfixtest/newtest/chldiatos_Omon_EC-Earth3-ESM-1_abrupt-4xCO2_r1i1p1f1_gn_195401-195412.nc


2. When cmor-fixer.py is executed with the --olist flag, it writes the list-of-modified-files.txt to the current directory, which currently has to be the same directory as the one containing cmor-fixer.py. If this directory cannot be written into, the --olist flag results in an error.
This is a problem if cmor-fixer is on a read-only media, such as in a container, and the list of modified files is needed.
Solution: we need to be able to specify an output directory for the file to be written into.

pwd
/home/pchengi/cmor-fixer
(cmorfixer) pchengi@thebeast:~/cmor-fixer$ ./cmor-fixer.py --verbose --npp 1 --olist --dry /home/pchengi/cmorfixtest/newtest
Traceback (most recent call last):
  File "/home/pchengi/cmor-fixer/./cmor-fixer.py", line 354, in <module>
    main()
    ~~~~^^
  File "/home/pchengi/cmor-fixer/./cmor-fixer.py", line 319, in main
    ofile = open(ofilename, 'w') if args.olist else None
            ~~~~^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'list-of-modified-files.txt'


Output from fixed code:
pwd
/home/pchengi/cmor-fixer_modified/cmor-fixer
(cmorfixer) pchengi@thebeast:~/cmor-fixer_modified/cmor-fixer$ ./cmor-fixer.py --verbose --npp 1 --olist --dry /home/pchengi/cmorfixtest/newtest --output-dir /home/pchengi/outputdir
2024-11-01 14:05:24 INFO:cmor-fixer.py: Replacing the longitude and latitude t-grid vertices for vertices_longitude (none) in /home/pchengi/cmorfixtest/newtest/chldiatos_Omon_EC-Earth3-ESM-1_abrupt-4xCO2_r1i1p1f1_gn_195401-195412.nc

cd /home/pchengi

pwd
/home/pchengi
(cmorfixer) pchengi@thebeast:~$ /home/pchengi/cmor-fixer_modified/cmor-fixer/cmor-fixer.py --verbose --npp 1 --olist --dry /home/pchengi/cmorfixtest/newtest --output-dir /home/pchengi/outputdir
2024-11-01 14:07:06 WARNING:cmor-fixer.py: Output file name /home/pchengi/outputdir/list-of-modified-files.txt already exists, trying /home/pchengi/outputdir/list-of-modified-files-2.txt...
2024-11-01 14:07:06 INFO:cmor-fixer.py: Replacing the longitude and latitude t-grid vertices for vertices_longitude (none) in /home/pchengi/cmorfixtest/newtest/chldiatos_Omon_EC-Earth3-ESM-1_abrupt-4xCO2_r1i1p1f1_gn_195401-195412.nc